### PR TITLE
Made filters work with "%" sign in value

### DIFF
--- a/packages/scandipwa/src/util/Url/Url.ts
+++ b/packages/scandipwa/src/util/Url/Url.ts
@@ -205,7 +205,9 @@ export const generateQuery = (
     history: History,
 ): string => Object.entries(keyValueObject)
     .reduce((acc, pair) => {
-        const [key, value] = pair;
+        const [key, rawValue] = pair;
+
+        const value = encodeURI(rawValue);
 
         const keyAndValueExist = !!key && !!value;
 


### PR DESCRIPTION
**Problem:**
* Fixes issue if some filter value has a "%" in it category page will stop adding/removing filters

**In this PR:**
* Added encoding of query params
